### PR TITLE
Allow multiple progress bars on a single line

### DIFF
--- a/js/controllers/direct_upload_field_controller.js
+++ b/js/controllers/direct_upload_field_controller.js
@@ -4,20 +4,23 @@ import { Controller } from "@hotwired/stimulus"
 class DirectUploadFieldController extends Controller {
   connect() {
     this.progressBars = {}
+
+    this.wrapper = document.createElement("div")
+    this.wrapper.className = "d-flex flex-wrap gap-2 mb-2"
+    this.element.insertAdjacentElement("beforebegin", this.wrapper)
   }
 
   setup(event) {
     const { id, file } = event.detail
 
     const progress = document.createElement("div")
-    progress.className = "progress mb-2"
+    progress.className = "progress"
     const progressBar = document.createElement("div")
-    progressBar.className = "progress-bar progress-bar-striped progress-bar-animated overflow-visible"
+    progressBar.className = "progress-bar progress-bar-striped progress-bar-animated overflow-visible px-3"
     progressBar.style.width = "0%"
     progressBar.textContent = file.name
+    this.wrapper.appendChild(progress)
     progress.appendChild(progressBar)
-
-    this.element.insertAdjacentElement("beforebegin", progress)
     this.progressBars[id] = progressBar
   }
 

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swiftvee/bootstrap-concerns",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "license": "MIT",
   "peerDependencies": {
     "bootstrap": "^5.3.0",


### PR DESCRIPTION
Issue https://github.com/swiftvee/angus/issues/7673

<img width="625" height="241" alt="Screenshot 2026-01-08 at 12 02 26" src="https://github.com/user-attachments/assets/0864b500-57d1-4d69-a0cc-9426cfa37914" />
<img width="1328" height="207" alt="Screenshot 2026-01-08 at 12 02 12" src="https://github.com/user-attachments/assets/eee989ba-c7f6-4842-8c1f-62f56816ccb8" />

### JS snippet to test the changes
```js
function showProgress(elementId) {
	const el = document.getElementById(elementId)
	const controller = window.Stimulus.getControllerForElementAndIdentifier(el, "direct-upload-field")

	const files = [
		{ id: "file.pdf", progress: 15 },
		{ id: "magna ullamcorper nisl.pdf", progress: 22 },
		{ id: "fusce malesuada quam egestas pretium ipsum ut molestie lectus pellentesque tincidunt.pdf", progress: 60 },
		{ id: "consequat metus in nisi scelerisque.pdf", progress: 99 },

	]

	files.forEach(({ id, progress }) => {
	  controller.setup({ detail: { id, file: { name: id } } })
	  controller.progress({ detail: { id, progress } })
	})
}
```
